### PR TITLE
Add new label type.UiFlaw to the requiredLabels

### DIFF
--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -63,6 +63,9 @@ const FEATURE_FLAW_DEFINITION =
   'of the project.</p>';
 const DOCUMENTATION_BUG_DEFINITION =
   '<p>A flaw in the documentation ' + '<span style="color:grey;">e.g. a missing step, a wrong instruction, typos</span></p>';
+const UI_FLAW_DEFINITION =
+  '<P>A flaw in the UI' +
+  '<span style="color:grey;">e.g. a poor display format, a bad UI design that significantly affects user interaction<span><P>';
 
 const ACCEPTED_DEFINITION = '<p>You accept it as a bug.</p>';
 const NOT_IN_SCOPE_DEFINITION =
@@ -83,6 +86,7 @@ export const LABEL_DEFINITIONS = {
   typeFunctionalityBug: FUNCTIONALITY_BUG_DEFINITION,
   typeFeatureFlaw: FEATURE_FLAW_DEFINITION,
   typeDocumentationBug: DOCUMENTATION_BUG_DEFINITION,
+  typeUiFlaw: UI_FLAW_DEFINITION,
   responseAccepted: ACCEPTED_DEFINITION,
   responseNotInScope: NOT_IN_SCOPE_DEFINITION,
   responseRejected: REJECTED_DEFINITION,
@@ -101,7 +105,8 @@ const REQUIRED_LABELS = {
   type: {
     DocumentationBug: new Label('type', 'DocumentationBug', COLOR_PURPLE_LIGHT, DOCUMENTATION_BUG_DEFINITION),
     FeatureFlaw: new Label('type', 'FeatureFlaw', COLOR_PURPLE_LIGHT, FEATURE_FLAW_DEFINITION),
-    FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION)
+    FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION),
+    UiBug: new Label('type', 'UiFlaw', COLOR_PURPLE, UI_FLAW_DEFINITION)
   },
   response: {
     Accepted: new Label('response', 'Accepted', COLOR_GREEN, ACCEPTED_DEFINITION),


### PR DESCRIPTION
### Summary:
Complete CATcher tutorial task 1, adding a new label.

### Changes Made:
A new Ui.Flaw label is added as a label. Users can add it as a label using the label drop down.

![Screenshot 2025-06-21 170640](https://github.com/user-attachments/assets/92aa5382-c963-4402-b423-2b8286598557)

### Proposed Commit Message:
```
Add new Ui.Flaw label to the exisiting app

New label allows users to mark bugs related to UI as a Ui.Flaw.
```