### PR TITLE
Delete unused labels from the current github repo

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -34,6 +34,7 @@ import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.serv
 import { LoggingService } from './logging.service';
 import { GithubRestIssue } from '../models/github/github-rest-issue';
 import { createOAuthUserAuth } from '@octokit/auth-oauth-user';
+import { Label } from '../models/label.model';
 
 const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
@@ -352,6 +353,14 @@ export class GithubService {
    */
   createLabel(formattedLabelName: string, labelColor: string): void {
     octokit.issues.createLabel({ owner: ORG_NAME, repo: REPO, name: formattedLabelName, color: labelColor });
+  }
+
+  /**
+   * Deletes a label in the current repository.
+   * @param label - label to be deleted.
+   */
+  deleteLabel(label: Label): void {
+    octokit.issues.deleteLabel({ owner: ORG_NAME, repo: REPO, name: label.getFormattedName() });
   }
 
   /**

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -312,16 +312,16 @@ export class LabelService {
    */
   private removeExtraLabelsFromRepo(actualLabels: Label[], requiredLabels: Label[]): void {
     actualLabels.forEach((label) => {
-      //find a label in the requiredLabels that has the same name as the existing labels.
+      // Find a label in the requiredLabels that has the same name as the existing labels
       const matchedRequiredLabels = requiredLabels.filter((requiredLabel) => requiredLabel.getFormattedName() === label.getFormattedName());
 
       if (matchedRequiredLabels.length === 0) {
-        //It is not the same as any any required labels, delete this label from current repo
+        // It is not the same as any any required labels, delete this label from current repo
         this.githubService.deleteLabel(label);
       } else if (matchedRequiredLabels.length === 1) {
-        // a match is found in the required label -> do nothing
+        // A match is found in the required label -> do nothing
       } else {
-        //multiple corresponding labels have been found in requiredLabels
+        // Multiple corresponding labels have been found in requiredLabels
         throw new Error('unexpected error: the required labels has multiple labels of the same name: ' + label.getFormattedName());
       }
     });

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -188,6 +188,10 @@ export class LabelService {
       map((response) => {
         this.ensureRepoHasRequiredLabels(response, LabelService.getRequiredLabelsAsArray(needAllLabels));
         return response;
+      }),
+      map((response) => {
+        this.removeExtraLabelsFromRepo(response, LabelService.getRequiredLabelsAsArray(needAllLabels));
+        return response;
       })
     );
   }
@@ -295,6 +299,30 @@ export class LabelService {
         }
       } else {
         throw new Error('Unexpected error: the repo has multiple labels with the same name ' + label.getFormattedName());
+      }
+    });
+  }
+
+  /**
+   * Removes all the extra labels which are not required from the current repo.
+   * Compares all the exisiting labels in the repo against the required labels. If a label is not found among the required
+   * labels, delete it from the current repo.
+   * @param actualLabels - labels in the repo
+   * @param requiredLabels - required labels
+   */
+  private removeExtraLabelsFromRepo(actualLabels: Label[], requiredLabels: Label[]): void {
+    actualLabels.forEach((label) => {
+      //find a label in the requiredLabels that has the same name as the existing labels.
+      const matchedRequiredLabels = requiredLabels.filter((requiredLabel) => requiredLabel.getFormattedName() === label.getFormattedName());
+
+      if (matchedRequiredLabels.length === 0) {
+        //It is not the same as any any required labels, delete this label from current repo
+        this.githubService.deleteLabel(label);
+      } else if (matchedRequiredLabels.length === 1) {
+        // a match is found in the required label -> do nothing
+      } else {
+        //multiple corresponding labels have been found in requiredLabels
+        throw new Error('unexpected error: the required labels has multiple labels of the same name: ' + label.getFormattedName());
       }
     });
   }


### PR DESCRIPTION
### Summary:
Complete CATcher tutorial task 2, removing unnecessary labels from current github repo when new issues are created on CATcher.

### Changes Made:
When creating new issues on CATcher, unnecessary labels are removed from the github repo linked to the CATcher phase.

#### Before:
Only 3 labels availabel for issues in this repo. One of them is not a required label for CATcher.
![image](https://github.com/user-attachments/assets/476cb1d0-c3dd-4451-9831-56b18dd428e3)

#### After creating a new issue on CATcher:
All required labels are included. All labels not required by CATcher are removed.
![image](https://github.com/user-attachments/assets/38c87a31-a188-4896-b234-cf440085818e)

### Proposed Commit Message:
```
Remove unused label from current github repo when creating new issue on CATcher.
```