### PR TITLE
Implement search by label severity for posted issues under bug reporting phase

### DIFF
--- a/src/app/phase-bug-reporting/issues-posted/issues-posted.component.css
+++ b/src/app/phase-bug-reporting/issues-posted/issues-posted.component.css
@@ -1,0 +1,3 @@
+.form-spacing {
+  margin-left: 16px;
+}

--- a/src/app/phase-bug-reporting/issues-posted/issues-posted.component.html
+++ b/src/app/phase-bug-reporting/issues-posted/issues-posted.component.html
@@ -12,6 +12,12 @@
       <mat-form-field class="full-grid-width">
         <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
+
+      <mat-form-field class="form-spacing">
+        <mat-select placeholder="Severity" (selectionChange)="applyLabelFilter($event.value)">
+          <mat-option *ngFor="let labelValue of severityFilterLabels" [value]="labelValue">{{ labelValue }}</mat-option>
+        </mat-select>
+      </mat-form-field>
     </mat-grid-tile>
 
     <mat-grid-tile>

--- a/src/app/phase-bug-reporting/issues-posted/issues-posted.component.ts
+++ b/src/app/phase-bug-reporting/issues-posted/issues-posted.component.ts
@@ -4,6 +4,8 @@ import { UserService } from '../../core/services/user.service';
 import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
 import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/issue-tables.component';
 import { Issue } from '../../core/models/issue.model';
+import { Label } from '../../core/models/label.model';
+import { LabelCategory, LabelService } from '../../core/services/label.service';
 
 @Component({
   selector: 'app-issues-posted',
@@ -14,18 +16,31 @@ export class IssuesPostedComponent implements OnInit {
   readonly displayedColumns = [TABLE_COLUMNS.NO, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.DELETE_ISSUE, ACTION_BUTTONS.FIX_ISSUE];
   filter: (issue: Issue) => boolean;
+  labelFilter: (issue: Issue) => boolean;
+
+  severityFilterLabels = this.labelService
+    .getLabelList('severity')
+    .map((label) => label.labelValue)
+    .concat('None');
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  constructor(public permissions: PermissionService, public userService: UserService) {}
+  constructor(public permissions: PermissionService, public userService: UserService, public labelService: LabelService) {}
 
   ngOnInit() {
     this.filter = (issue: Issue): boolean => {
+      return issue.isIssueOpened();
+    };
+    this.labelFilter = (issue: Issue): boolean => {
       return issue.isIssueOpened();
     };
   }
 
   applyFilter(filterValue: string) {
     this.table.issues.filter = filterValue;
+  }
+
+  applyLabelFilter(filterLabelValue: string) {
+    this.table.issues.filterLabel = filterLabelValue;
   }
 }

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -7,10 +7,11 @@ import { Issue } from '../../core/models/issue.model';
 import { IssueService } from '../../core/services/issue.service';
 import { paginateData } from './issue-paginator';
 import { getSortedData } from './issue-sorter';
-import { applySearchFilter } from './search-filter';
+import { applyLabelFilter, applySearchFilter } from './search-filter';
 
 export class IssuesDataTable extends DataSource<Issue> {
   private filterChange = new BehaviorSubject('');
+  private filterLabelChange = new BehaviorSubject('None');
   private teamFilterChange = new BehaviorSubject('');
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
@@ -39,6 +40,7 @@ export class IssuesDataTable extends DataSource<Issue> {
 
   disconnect() {
     this.filterChange.complete();
+    this.filterLabelChange.complete();
     this.teamFilterChange.complete();
     this.issuesSubject.complete();
     this.issueSubscription.unsubscribe();
@@ -51,6 +53,7 @@ export class IssuesDataTable extends DataSource<Issue> {
       this.paginator.page,
       this.sort.sortChange,
       this.filterChange,
+      this.filterLabelChange,
       this.teamFilterChange
     ];
 
@@ -65,6 +68,7 @@ export class IssuesDataTable extends DataSource<Issue> {
           data = getSortedData(this.sort, data);
           data = this.getFilteredTeamData(data);
           data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, data);
+          data = applyLabelFilter(this.filterLabel, data);
           data = paginateData(this.paginator, data);
 
           return data;
@@ -81,6 +85,14 @@ export class IssuesDataTable extends DataSource<Issue> {
 
   set filter(filter: string) {
     this.filterChange.next(filter);
+  }
+
+  get filterLabel(): string {
+    return this.filterLabelChange.value;
+  }
+
+  set filterLabel(labelValue: string) {
+    this.filterLabelChange.next(labelValue);
   }
 
   get teamFilter(): string {

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -1,3 +1,4 @@
+import { Label } from '../../core/models/label.model';
 import { Issue } from '../../core/models/issue.model';
 import { IssueService } from '../../core/services/issue.service';
 import { TABLE_COLUMNS } from './issue-tables-columns';
@@ -39,6 +40,21 @@ export function applySearchFilter(filter: string, displayedColumn: string[], iss
   return result;
 }
 
+export function applyLabelFilter(filterLabelValue: string, data: Issue[]) {
+  console.log(filterLabelValue);
+  if (filterLabelValue === 'None') {
+    return data;
+  }
+  const result = data.slice().filter((issue: Issue) => {
+    if (mathSeverity(issue, filterLabelValue)) {
+      return true;
+    } else {
+      return false;
+    }
+  });
+  return result;
+}
+
 function containsSearchKey(item: string, searchKey: string): boolean {
   return item.indexOf(searchKey) !== -1;
 }
@@ -64,4 +80,8 @@ function matchesTitle(issue: Issue, searchKey: string): boolean {
 function matchesOtherColumns(issue: Issue, column: string, searchKey: string): boolean {
   const searchStr = String(issue[column]).toLowerCase();
   return containsSearchKey(searchStr, searchKey);
+}
+
+function mathSeverity(issue: Issue, labelValue: string) {
+  return issue.severity === labelValue;
 }


### PR DESCRIPTION
### Summary:
Implement filter by severity feature for reported bugs under bug reporting phase.

### Changes Made:

Besides the original search input box, a new dropdown box is implemented to filter the issues by their severity. Initially, all issues are displayed without any filtering by default. 

![image](https://github.com/user-attachments/assets/d7e78dcf-3155-40c1-88e5-6145223cd659)

In dropdown, users can filter the issues by choosing various severities. The severities are taken from label service.

![image](https://github.com/user-attachments/assets/b99d9106-73f0-4ca4-8ce2-fad5722cff78)

By choosing a severity, only issues with corresponding severity will be displayed. The other issues are hidden.

![image](https://github.com/user-attachments/assets/fbf242c4-a0e5-40de-9cdf-098737f838b8)

When used together with original search function, the issues will first be filtered by `Search` parameter, followed by the severity.

![image](https://github.com/user-attachments/assets/aede2f1c-b1c4-400c-ad89-e657a1e751d5)

Choosing the `None` tab will display all issues filtered by `Search` parameter only.

![image](https://github.com/user-attachments/assets/395098fa-d6e4-46b6-ae24-ea5856c04b29)


### Proposed Commit Message:
```
Implement filter by severity feature for issues created under bug reporting phase.

When used together with search, the issues will be filtered by the search parameter first, the remaining issues are then filtered again according to severity.

The severities in dropdown are obtained through label service.

This feature might be very useful for dev team response phase, when large number of reponse is received by the dev team.
```